### PR TITLE
Fix Ms Earth not being centre over 2K res

### DIFF
--- a/src/components/glaube.js
+++ b/src/components/glaube.js
@@ -202,6 +202,7 @@ const aboutPageComponents = {
             <img
               src={signUpIllustration}
               alt="OpenStreetMap"
+              className="mx-auto"
             />
           ),
         },


### PR DESCRIPTION
Fixes #383

Center the Ms Earth 🌏 horizontally on screens with a resolution of 2K or higher.

* Add the `mx-auto` class to the image element in `src/components/glaube.js` to center the mascot horizontally.
